### PR TITLE
fix: remove duplicate __dirname causing server crash

### DIFF
--- a/server.js
+++ b/server.js
@@ -161,8 +161,6 @@ app.post('/api/assistants/:id/messages', async (req, res) => {
 
 // Serve static files after build
 
-const __dirname = path.resolve();
-
 app.use(express.static(path.join(__dirname, 'dist')));
 app.get('*', (_, res) => {
   res.sendFile(path.join(__dirname, 'index.html'));


### PR DESCRIPTION
## Summary
- eliminate redeclared `__dirname` that prevented server from starting

## Testing
- `npm run server`
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68a63f77b9448324b41099879ae3f3e0